### PR TITLE
Add exec to asterisk command

### DIFF
--- a/Asterisk/run.sh
+++ b/Asterisk/run.sh
@@ -116,7 +116,7 @@ fi
 
 bashio::log.info "Starting Asterisk..."
 
-asterisk -vvvvvvvvv -ddddddddddd -f
+exec asterisk -vvvvvvvvv -ddddddddddd -f
 
 # RUN ANOTHER SCRIPT UPDATING THE ENTITIES AND KEEP ASTERISK CONSOLE HERE
 


### PR DESCRIPTION
This delegates the execution to Asterisk, so that it can handle signals
properly.
