### PR TITLE
Allow to set IP in configuration

### DIFF
--- a/asterisk/DOCS.md
+++ b/asterisk/DOCS.md
@@ -25,6 +25,7 @@ ami_password: my-password-of-choice
 auto_add: true
 certfile: fullchain.pem
 keyfile: privkey.pem
+ip: 192.168.0.1
 ```
 
 **Note**: _This is just an example, don't copy and past it! Create your own!_
@@ -48,3 +49,7 @@ The certificate file to use for SSL.
 The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default_
+
+### Option: `ip`
+
+HA server ip. (Only this IP will be allowed to connect)

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -20,6 +20,7 @@ options:
   auto_add: true
   certfile: fullchain.pem
   keyfile: privkey.pem
+  ip: 192.168.0.1
 schema:
   ami_password: password
   auto_add: bool

--- a/asterisk/rootfs/run.sh
+++ b/asterisk/rootfs/run.sh
@@ -36,7 +36,7 @@ bashio::log.info "Configuring Asterisk..."
 
 bashio::var.json \
     password "$(bashio::config 'ami_password')" \
-    ip "$(getent hosts homeassistant | awk '{ print $1 }')" |
+    ip "$(bashio::config 'ip')" |
     tempio \
         -template /usr/share/tempio/manager.conf.gtpl \
         -out /etc/asterisk/manager.conf


### PR DESCRIPTION
I would suggest to allow users to set IP in configuration instead of trying to fetch with a command (which does not work and always will get internal docker ip).