### PR TITLE
Use host_network

### DIFF
--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -25,41 +25,4 @@ schema:
   auto_add: bool
   certfile: str
   keyfile: str
-ports:
-  "10000": 10000
-  "10001": 10001
-  "10002": 10002
-  "10003": 10003
-  "10004": 10004
-  "10005": 10005
-  "10006": 10006
-  "10007": 10007
-  "10008": 10008
-  5038/tcp: 5038
-  8089/tcp: 8089
-  8088/tcp: 8088
-  5060/tcp: 5060
-  5060/udp: 5060
-  5160/tcp: 5160
-  5160/udp: 5160
-  4569/udp: 4569
-  2727/udp: 2727
-ports_description:
-  "10000": RTP
-  "10001": RTP
-  "10002": RTP
-  "10003": RTP
-  "10004": RTP
-  "10005": RTP
-  "10006": RTP
-  "10007": RTP
-  "10008": RTP
-  5038/tcp: Port for AMI
-  8089/tcp: Port for WSS
-  8088/tcp: Port for WS
-  5060/tcp: Port for SIP
-  5060/udp: Port for SIP
-  5160/tcp: Port for SIP
-  5160/udp: Port for SIP
-  4569/udp: Port for IAX2
-  2727/udp: Port for MGCP
+host_network: true

--- a/asterisk/rootfs/etc/asterisk/rtp.conf
+++ b/asterisk/rootfs/etc/asterisk/rtp.conf
@@ -1,3 +1,0 @@
-[general]
-rtpstart=10000
-rtpend=10008


### PR DESCRIPTION
This tentatively fix #33, as suggested in https://community.home-assistant.io/t/add-support-for-port-ranges-in-add-on-config-yaml/375695/7.

However, this should be immediately switched back to normal port forwardings once support for port range is implemented.