### PR TITLE
Add support for ingress

### DIFF
--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -17,7 +17,7 @@ RUN S6_ARCH="${BUILD_ARCH}" \
     && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${S6_ARCH}.tar.gz" \
         | tar zxvf - -C /
 
-# Install Asterisk
+# Install asterisk, rsync and nginx
 ARG ASTERISK_VERSION=18.2.2-r5
 RUN apk add --update --no-cache \
     asterisk="${ASTERISK_VERSION}" \
@@ -27,7 +27,8 @@ RUN apk add --update --no-cache \
     asterisk-sounds-moh="${ASTERISK_VERSION}" \
     asterisk-speex="${ASTERISK_VERSION}" \
     asterisk-dahdi="${ASTERISK_VERSION}" \
-    rsync=~3.2.3-r5
+    rsync=~3.2.3-r5 \
+    nginx=~1.20.2-r0
 
 # Install mailbox server
 RUN apk add --no-cache --virtual .build-dependencies build-base=0.5-r2 \

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -10,6 +10,9 @@ arch:
   - aarch64
   - amd64
   - i386
+ingress: true
+ingress_port: 0
+ingress_entry: /ws
 homeassistant_api: true
 map:
   - config:rw

--- a/asterisk/rootfs/etc/cont-init.d/nginx.sh
+++ b/asterisk/rootfs/etc/cont-init.d/nginx.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Configures NGINX
+# ==============================================================================
+
+# shellcheck shell=bash
+
+bashio::log.info "Configuring NGINX..."
+
+# Get assigned Ingress port
+ingress_port=$(bashio::addon.ingress_port)
+readonly ingress_port
+
+bashio::var.json \
+    ingress_port "^${ingress_port}" |
+    tempio \
+    -template /usr/share/tempio/ingress.conf.gtpl \
+    -out /etc/nginx/http.d/ingress.conf

--- a/asterisk/rootfs/etc/services.d/nginx/finish
+++ b/asterisk/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/execlineb -S1
+# ==============================================================================
+# Take down the S6 supervision tree when NGINX fails
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/asterisk/rootfs/etc/services.d/nginx/run
+++ b/asterisk/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,13 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Start the NGINX service
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
+
+# shellcheck shell=bash
+
+bashio::log.info "Starting NGINX..."
+
+## Run NGINX
+
+exec nginx -g "daemon off;error_log /dev/stdout debug;"

--- a/asterisk/rootfs/usr/share/tempio/ingress.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/ingress.conf.gtpl
@@ -1,0 +1,20 @@
+upstream asterisk {
+  server 127.0.0.1:8088;
+}
+server {
+  listen {{ .ingress_port }};
+  allow 172.30.32.2;
+  deny all;
+  location /ws {
+    proxy_buffers 8 32k;
+    proxy_buffer_size 64k;
+    proxy_pass http://asterisk/ws;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 999999999;
+  }
+}


### PR DESCRIPTION
Perhaps we may need to set `ingress_stream: true`.

https://developers.home-assistant.io/blog/2021/08/24/supervisor_update/#streaming-ingress

But I have no clue. Also, we may need to start a NGINX server inside the container as well,
as mentioned in https://developers.home-assistant.io/docs/add-ons/presentation#basic-ingress-example-with-nginx.

What matters is that it's 100% possible to make this work :)