### PR TITLE
added TLS settings for asterisk

### DIFF
--- a/asterisk/rootfs/etc/asterisk/sip.conf
+++ b/asterisk/rootfs/etc/asterisk/sip.conf
@@ -3,6 +3,11 @@ udpbindaddr=0.0.0.0
 bind=0.0.0.0
 bindaddr=0.0.0.0
 protocol=udp
+tlsenable=yes
+tlsbindaddr=0.0.0.0
+tlscertfile=/etc/asterisk/keys/asterisk.pem
+tlscipher=ALL
+tlsclientmethod=ALL
 
 #include sip_default.conf
 


### PR DESCRIPTION
I use sip_custom.conf for testing with a yealink hardware phone. But TLS for SIP was not available. These lines allow TLS on SIP.