### PR TITLE
Remove default passwords

### DIFF
--- a/asterisk/DOCS.md
+++ b/asterisk/DOCS.md
@@ -14,7 +14,7 @@ Follow these steps to get the add-on installed on your system:
 ## Using
 
 1. The certificate to your registered domain should already be created via the [Duck DNS](https://github.com/home-assistant/hassio-addons/tree/master/duckdns) or [Let's Encrypt](https://github.com/home-assistant/hassio-addons/tree/master/letsencrypt) add-on or another method. Make sure that the certificate files exist in the `/ssl` directory.
-1. Check the add-on configuration by going to the **_Configuration_** tab. For example, you may want to change the default AMI Password to something else.
+1. Check the add-on configuration by going to the **_Configuration_** tab. You need to at least fill the _AMI Password_ and the _Auto add secret_ (if you leave _Auto add extensions_ enabled).
 1. Start the add-on by clicking in the **_START_** button.
 
 **Note**: _Remember to restart the add-on when the configuration is changed._

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -15,17 +15,15 @@ map:
   - config:rw
   - ssl
 options:
-  ami_password: c32d3bd655d9226ffc062751ab9d1058
   video_support: true
   auto_add: true
-  auto_add_secret: 1234abcd
   certfile: fullchain.pem
   keyfile: privkey.pem
 schema:
   ami_password: password
   video_support: bool
   auto_add: bool
-  auto_add_secret: password
+  auto_add_secret: password?
   certfile: str
   keyfile: str
 host_network: true

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -67,10 +67,16 @@ else
 fi
 readonly video_support
 
+auto_add=$(bashio::config 'auto_add')
+auto_add_secret=$(bashio::config 'auto_add_secret')
+if bashio::var.true "${auto_add}" && bashio::var.is_empty "${auto_add_secret}"; then
+    bashio::exit.nok "'auto_add_secret' must be set when 'auto_add' is enabled"
+fi
+
 bashio::var.json \
-    auto_add "^$(bashio::config 'auto_add')" \
+    auto_add "^${auto_add}" \
+    auto_add_secret "${auto_add_secret}" \
     video_support "${video_support}" \
-    auto_add_secret "$(bashio::config 'auto_add_secret')" \
     persons "^${persons}" |
     tempio \
         -template /usr/share/tempio/sip_default.conf.gtpl \


### PR DESCRIPTION
This is a security measure to ensure users do not rely on the default password.

Other add-ons do the same.