### PR TITLE
Remove ssl option and add generate_ssl_cert instead

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Start Home Assistant",
       "type": "shell",
-      "command": "bash supervisor_run",
+      "command": "supervisor_run",
       "group": {
         "kind": "test",
         "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Start Home Assistant",
       "type": "shell",
-      "command": "supervisor_run",
+      "command": "bash supervisor_run",
       "group": {
         "kind": "test",
         "isDefault": true

--- a/asterisk/DOCS.md
+++ b/asterisk/DOCS.md
@@ -34,11 +34,14 @@ Creates a extension for every [person](https://www.home-assistant.io/integration
 ### Option: `auto_add_secret`
 The secret for the auto generated extensions.
 
+### Option: `generate_ssl_cert`
+Enables/disables the generation of a self-signed certificate for use with the SSL interfaces (WSS and TLS).
+
 ### Option: `certfile`
-The certificate file to use for SSL in your `/ssl/` folder.
+The certificate file to use for SSL in your `/ssl/` folder, when `generate_ssl_cert` is disabled.
 
 ### Option: `keyfile`
-The key file to use for SSL in your `/ssl/` folder.
+The key file to use for SSL in your `/ssl/` folder, when `generate_ssl_cert` is disabled.
 
 ### Option: `mailbox_server`
 Enables the mailbox server to send voicemails to the Asterisk mailbox integration.

--- a/asterisk/DOCS.md
+++ b/asterisk/DOCS.md
@@ -34,20 +34,11 @@ Creates a extension for every [person](https://www.home-assistant.io/integration
 ### Option: `auto_add_secret`
 The secret for the auto generated extensions.
 
-### Option: `ssl`
-Enables/disables the SSL/TLS/HTTPS Asterisk interfaces.
-
-Enabled by default.
-
 ### Option: `certfile`
-The certificate file to use for SSL in your `/ssl/` folder, when SSL is enabled.
-
-The default is `fullchain.pem`.
+The certificate file to use for SSL in your `/ssl/` folder.
 
 ### Option: `keyfile`
-The key file to use for SSL in your `/ssl/` folder, when SSL is enabled.
-
-The default is `privkey.pem`.
+The key file to use for SSL in your `/ssl/` folder.
 
 ### Option: `mailbox_server`
 Enables the mailbox server to send voicemails to the Asterisk mailbox integration.

--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -28,7 +28,8 @@ RUN apk add --update --no-cache \
     asterisk-speex="${ASTERISK_VERSION}" \
     asterisk-dahdi="${ASTERISK_VERSION}" \
     rsync=~3.2.3-r5 \
-    nginx=~1.20.2-r0
+    nginx=~1.20.2-r0 \
+    openssl=~1.1.1l-r8
 
 # Install mailbox server
 RUN apk add --no-cache --virtual .build-dependencies build-base=0.5-r2 \

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -20,7 +20,7 @@ map:
 options:
   video_support: true
   auto_add: true
-  generate_cert: false
+  generate_ssl_cert: false
   certfile: fullchain.pem
   keyfile: privkey.pem
   mailbox: false
@@ -31,7 +31,7 @@ schema:
   video_support: bool
   auto_add: bool
   auto_add_secret: password?
-  generate_cert: bool
+  generate_ssl_cert: bool
   certfile: str
   keyfile: str
   mailbox: bool

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -20,7 +20,6 @@ map:
 options:
   video_support: true
   auto_add: true
-  ssl: true
   certfile: fullchain.pem
   keyfile: privkey.pem
   mailbox: false
@@ -31,7 +30,6 @@ schema:
   video_support: bool
   auto_add: bool
   auto_add_secret: password?
-  ssl: bool
   certfile: str
   keyfile: str
   mailbox: bool

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -20,6 +20,7 @@ map:
 options:
   video_support: true
   auto_add: true
+  generate_cert: false
   certfile: fullchain.pem
   keyfile: privkey.pem
   mailbox: false
@@ -30,6 +31,7 @@ schema:
   video_support: bool
   auto_add: bool
   auto_add_secret: password?
+  generate_cert: bool
   certfile: str
   keyfile: str
   mailbox: bool

--- a/asterisk/rootfs/etc/asterisk/sip.conf
+++ b/asterisk/rootfs/etc/asterisk/sip.conf
@@ -3,13 +3,11 @@ udpbindaddr=0.0.0.0
 bind=0.0.0.0
 bindaddr=0.0.0.0
 protocol=udp
-{{ if .ssl -}}
 tlsenable=yes
 tlsbindaddr=0.0.0.0
 tlscertfile=/etc/asterisk/keys/asterisk.pem
 tlscipher=ALL
 tlsclientmethod=ALL
-{{- end }}
 
 #include sip_default.conf
 

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -10,38 +10,32 @@ if ! bashio::fs.directory_exists '/config/asterisk'; then
         bashio::exit.nok 'Failed to create initial asterisk config folder'
 fi
 
-ssl=$(bashio::config 'ssl')
+bashio::log.info "Configuring certificate..."
+
 certfile="/ssl/$(bashio::config 'certfile')"
 keyfile="/ssl/$(bashio::config 'keyfile')"
-target_certfile="/etc/asterisk/keys/fullchain.pem"
-target_keyfile="/etc/asterisk/keys/privkey.pem"
-readonly ssl certfile keyfile target_certfile target_keyfile
+readonly certfile keyfile
 
-if bashio::var.true "${ssl}"; then
-    bashio::log.info "Configuring certificate..."
-
-    if bashio::var.is_empty "${certfile}" || bashio::var.is_empty "${keyfile}"; then
-        bashio::exit.nok "'certfile' and 'keyfile' must be set when 'ssl' is enabled"
-    fi
-
-    if ! bashio::fs.file_exists "${certfile}"; then
-        bashio::exit.nok "Certificate file at '${certfile}' was not found"
-    fi
-
-    if ! bashio::fs.file_exists "${keyfile}"; then
-        bashio::exit.nok "Key file at '${keyfile}' was not found"
-    fi
-
-    mkdir -p /etc/asterisk/keys
-
-    cp -f "${certfile}" "${target_certfile}"
-    cp -f "${keyfile}" "${target_keyfile}"
-    cat "${target_keyfile}" <(echo) "${target_certfile}" >/etc/asterisk/keys/asterisk.pem
-    chown asterisk: /etc/asterisk/keys/*.pem
-    chmod 600 /etc/asterisk/keys/*.pem
-
-    cp -a -f /etc/asterisk/keys/. /config/asterisk/keys/ || bashio::exit.nok 'Failed to update certificate'
+if ! bashio::fs.file_exists "${certfile}"; then
+    bashio::exit.nok "Certificate file at ${certfile} was not found"
 fi
+
+if ! bashio::fs.file_exists "${keyfile}"; then
+    bashio::exit.nok "Key file at ${keyfile} was not found"
+fi
+
+readonly target_certfile="/etc/asterisk/keys/fullchain.pem"
+readonly target_keyfile="/etc/asterisk/keys/privkey.pem"
+
+mkdir -p /etc/asterisk/keys
+
+cp -f "${certfile}" "${target_certfile}"
+cp -f "${keyfile}" "${target_keyfile}"
+cat "${target_keyfile}" <(echo) "${target_certfile}" > /etc/asterisk/keys/asterisk.pem
+chown asterisk: /etc/asterisk/keys/*.pem
+chmod 600 /etc/asterisk/keys/*.pem
+
+cp -a -f /etc/asterisk/keys/. /config/asterisk/keys/ || bashio::exit.nok 'Failed to update certificate'
 
 bashio::log.info "Configuring Asterisk..."
 
@@ -54,18 +48,11 @@ bashio::var.json \
         -out /config/asterisk/manager.conf
 
 bashio::var.json \
-    ssl "^${ssl}" \
     certfile "${target_certfile}" \
     keyfile "${target_keyfile}" |
     tempio \
-        -template /usr/share/tempio/http.conf.gtpl \
-        -out /config/asterisk/http.conf
-
-bashio::var.json \
-    ssl "^${ssl}" |
-    tempio \
-        -template /usr/share/tempio/sip.conf.gtpl \
-        -out /config/asterisk/sip.conf
+    -template /usr/share/tempio/http.conf.gtpl \
+    -out /config/asterisk/http.conf
 
 persons="$(curl -s -X GET \
     -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
@@ -89,7 +76,6 @@ fi
 bashio::var.json \
     auto_add "^${auto_add}" \
     auto_add_secret "${auto_add_secret}" \
-    ssl "^${ssl}" \
     video_support "${video_support}" \
     persons "^${persons}" |
     tempio \
@@ -97,4 +83,4 @@ bashio::var.json \
         -out /config/asterisk/sip_default.conf
 
 rsync -a -v --ignore-existing /etc/asterisk/. /config/asterisk/ || bashio::exit.nok 'Failed to make sample configs.' # Doesn't overwrite
-cp -a -f /config/asterisk/. /etc/asterisk/ || bashio::exit.nok 'Failed to get config from /config/asterisk.'         # Does overwrite
+cp -a -f /config/asterisk/. /etc/asterisk/ || bashio::exit.nok 'Failed to get config from /config/asterisk.' # Does overwrite

--- a/asterisk/rootfs/usr/share/tempio/http.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/http.conf.gtpl
@@ -2,9 +2,7 @@
 enabled=yes
 bindaddr=0.0.0.0
 bindport=8088
-{{ if .ssl -}}
 tlsenable=yes
 tlsbindaddr=0.0.0.0:8089
 tlscertfile={{ .certfile }}
 tlsprivatekey={{ .keyfile }}
-{{- end }}

--- a/asterisk/rootfs/usr/share/tempio/sip_default.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/sip_default.conf.gtpl
@@ -9,21 +9,17 @@ avpf=yes ; Tell Asterisk to use AVPF for this peer
 icesupport=yes ; Tell Asterisk to use ICE for this peer
 context=default ; Tell Asterisk which context to use when this peer is dialing
 directmedia=no ; Asterisk will relay media for this peer
+transport=wss,udp,tls ; Asterisk will allow this peer to register on UDP or WebSockets
 force_avp=yes ; Force Asterisk to use avp. Introduced in Asterisk 11.11
+dtlsenable=yes ; Tell Asterisk to enable DTLS for this peer
+dtlsverify=fingerprint ; Tell Asterisk to verify DTLS fingerprint
+dtlscertfile=/etc/asterisk/keys/asterisk.pem ; Tell Asterisk where your DTLS cert file is
+dtlssetup=actpass ; Tell Asterisk to use actpass SDP parameter when setting up DTLS
 rtcp_mux=yes ; Tell Asterisk to do RTCP mux
 dtmfmode=rfc2833
 qualify=no
 sendrpid=pai
 videosupport={{ .video_support }}
-{{ if .ssl -}}
-transport=wss,udp,tls ; Asterisk will allow this peer to register on UDP or WebSockets or TLS
-dtlsenable=yes ; Tell Asterisk to enable DTLS for this peer
-dtlsverify=fingerprint ; Tell Asterisk to verify DTLS fingerprint
-dtlscertfile=/etc/asterisk/keys/asterisk.pem ; Tell Asterisk where your DTLS cert file is
-dtlssetup=actpass ; Tell Asterisk to use actpass SDP parameter when setting up DTLS
-{{- else -}}
-transport=wss,udp ; Asterisk will allow this peer to register on UDP or WebSockets
-{{- end }}
 
 [my-codecs](!)
 allow=!all,ulaw,alaw,speex,gsm,g726,g723,h263,h263p,h264,vp8

--- a/asterisk/translations/en.yaml
+++ b/asterisk/translations/en.yaml
@@ -16,21 +16,19 @@ configuration:
   auto_add:
     name: Auto Add Extensions
     description: >-
-      Whether to enable the automatic creation of extensions for
+      Whether to enable the automatic creation of extensions for 
       every person registered in Home Assistant. They will have
       their number/username auto-generated starting from 100.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/disables the SSL/TLS/HTTPS Asterisk interfaces.
   certfile:
     name: Certificate File
     description: >-
-      The certificate file to use for SSL in your `/ssl/` folder, when SSL is enabled.
+      The certificate file to use for SSL. Note that this file must
+      exist in the /ssl/ folder.
   keyfile:
     name: Private Key File
     description: >-
-      The key file to use for SSL in your `/ssl/` folder, when SSL is enabled.
+      The private key file to use for SSL. Note that this file must
+      exist in the /ssl/ folder.
   mailbox:
     name: Mailbox Server
     description: >-

--- a/asterisk/translations/en.yaml
+++ b/asterisk/translations/en.yaml
@@ -19,16 +19,21 @@ configuration:
       Whether to enable the automatic creation of extensions for 
       every person registered in Home Assistant. They will have
       their number/username auto-generated starting from 100.
+  generate_ssl_cert:
+    name: Generate SSL Certifcate
+    description: >-
+      Enables/disables the generation of a self-signed certificate 
+      for use with the SSL interfaces (WSS and TLS).
   certfile:
     name: Certificate File
     description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
+      The certificate file to use for SSL in your `/ssl/` folder,
+      when `generate_ssl_cert` is disabled.
   keyfile:
     name: Private Key File
     description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
+      The key file to use for SSL in your `/ssl/` folder, when
+      `generate_ssl_cert` is disabled.
   mailbox:
     name: Mailbox Server
     description: >-


### PR DESCRIPTION
It turns out that it's impossible to make calls using SIP.JS to the WS (8088) interface of Asterisk. But, the WSS (8089) can still be used in reverse proxies normally, so this adds a new option called `generate_ssl_cert` which if enabled, will make the addon generate a self-signed certificate for Asterisk to use in WSS.

This way it works and it can be proxied.