### PR TITLE
Upgrade addon-base-python from 8.0.1 to 8.1.0

### DIFF
--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -1,21 +1,10 @@
 ARG BUILD_ARCH=amd64
-ARG BUILD_FROM=ghcr.io/hassio-addons/base-python/${BUILD_ARCH}:8.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base-python/${BUILD_ARCH}:8.1.0
 
 
 FROM $BUILD_FROM
 
 ARG BUILD_ARCH
-
-# Reinstall S6 Overlay as a fix to https://github.com/hassio-addons/addon-base-python/issues/102
-# This should be removed once a fix for it is released.
-# Taken from: https://github.com/hassio-addons/addon-base/blob/8343e5cabb52ad392b5166c9dcc8abb802afe101/base/Dockerfile#L40-L45
-# hadolint ignore=DL4006
-RUN S6_ARCH="${BUILD_ARCH}" \
-    && if [ "${BUILD_ARCH}" = "i386" ]; then S6_ARCH="x86"; fi \
-    && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
-    \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${S6_ARCH}.tar.gz" \
-        | tar zxvf - -C /
 
 # Install Asterisk
 ARG ASTERISK_VERSION=18.2.2-r5

--- a/asterisk/build.yaml
+++ b/asterisk/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/base-python/aarch64:8.0.1
-  amd64: ghcr.io/hassio-addons/base-python/amd64:8.0.1
-  armhf: ghcr.io/hassio-addons/base-python/armhf:8.0.1
-  armv7: ghcr.io/hassio-addons/base-python/armv7:8.0.1
-  i386: ghcr.io/hassio-addons/base-python/i386:8.0.1
+  aarch64: ghcr.io/hassio-addons/base-python/aarch64:8.1.0
+  amd64: ghcr.io/hassio-addons/base-python/amd64:8.1.0
+  armhf: ghcr.io/hassio-addons/base-python/armhf:8.1.0
+  armv7: ghcr.io/hassio-addons/base-python/armv7:8.1.0
+  i386: ghcr.io/hassio-addons/base-python/i386:8.1.0
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Asterisk"
   org.opencontainers.image.description: "PBX server for SIP devices like doorbells and phones."


### PR DESCRIPTION
And also remove the workaround for the missing s6-overlay binary, as it
got fixed in the newer version.

Closes #111